### PR TITLE
refactor: build html5-app in a separate Docker stage

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,9 +6,5 @@ git submodule foreach 'git submodule update --init'
 
 # Update and build html5 app
 git submodule update --init --remote venus-html5-app
-cd venus-html5-app/
-npm install
-npm run compile
-cd ..
 
 docker build . -t mqtt

--- a/dockerfile
+++ b/dockerfile
@@ -1,3 +1,9 @@
+FROM node:lts-alpine as html5-app
+COPY venus-html5-app .
+RUN npm install
+RUN npm run compile
+
+
 # venus-docker build
 FROM ubuntu
 WORKDIR /root
@@ -48,7 +54,7 @@ COPY simulations /root/simulations
 
 # Html5 app
 COPY venus_app.conf /etc/nginx/sites-available
-COPY venus-html5-app/dist/ /var/www/venus_app/
+COPY --from=html5-app ./dist/ /var/www/venus_app/
 RUN ln -s /etc/nginx/sites-available/venus_app.conf /etc/nginx/sites-enabled
 RUN rm /etc/nginx/sites-enabled/default
 

--- a/dockerfile
+++ b/dockerfile
@@ -1,6 +1,7 @@
 FROM node:lts-alpine as html5-app
-COPY venus-html5-app .
+COPY venus-html5-app/package.json .
 RUN npm install
+COPY venus-html5-app .
 RUN npm run compile
 
 


### PR DESCRIPTION
This way html5-app has a completely separate build stage, which is disposed of
once the build completes and only the static files are copied over.