### PR TITLE
dokerfiler: Fix venus-html5-app build by updating Alpine version

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,7 +1,10 @@
 # Compile html5 app
-FROM node:lts-alpine as html5-app
+FROM alpine:3.14 as html5-app
 COPY venus-html5-app/package.json .
 COPY venus-html5-app/package-lock.json .
+RUN apk add --no-cache npm
+RUN apk add --no-cache python3
+RUN apk add --no-cache build-base
 RUN npm install
 COPY venus-html5-app .
 ENV PUBLIC_URL=/


### PR DESCRIPTION
Build process does not suceed because one of the venus-html5-app
dependencies fails to build with node:lts-alpine.