### PR TITLE
feat(nginx): add mapping for /websocket-mqtt

### DIFF
--- a/venus_app.conf
+++ b/venus_app.conf
@@ -7,4 +7,11 @@ server {
   location / {
     try_files $uri $uri/ =404;
   }
+  location ~ ^/websocket-mqtt$ {
+    proxy_pass http://127.0.0.1:9001;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+  }
 }


### PR DESCRIPTION
This PR closes https://github.com/victronenergy/venus-docker/issues/20 by adding a `/websocket-mqtt` HTTP Upgrade mapping to the `venus-docker` nginx config file. That way HTML app served via NGINX can talk to MQTT Websocket directly by requesting HTTP Upgrade via `/websocket-mqtt` instead of talking to port 9001.